### PR TITLE
Update for Dalamud API 15 and FFXIV 7.5 compatibility

### DIFF
--- a/HUDLayoutHelper/HUDLayoutHelper.csproj
+++ b/HUDLayoutHelper/HUDLayoutHelper.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Dalamud.NET.Sdk/14.0.1">
+<Project Sdk="Dalamud.NET.Sdk/15.0.0">
   <PropertyGroup>
     <Version>0.0.0.3</Version>
     <Description>FFXIV HUD Layout Helper</Description>
@@ -7,8 +7,8 @@
     <RepoUrl>https://github.com/Mary-Usagi/FFXIV-HUDLayoutHelper</RepoUrl>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>
 	<IconUrl>https://raw.githubusercontent.com/Mary-Usagi/FFXIV-HUDLayoutHelper/refs/heads/main/images/icon.png</IconUrl>
-    <DalamudApiLevel>14</DalamudApiLevel>
-	<TestingDalamudApiLevel>14</TestingDalamudApiLevel>
+    <DalamudApiLevel>15</DalamudApiLevel>
+	<TestingDalamudApiLevel>15</TestingDalamudApiLevel>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 </Project>

--- a/HUDLayoutHelper/Plugin.cs
+++ b/HUDLayoutHelper/Plugin.cs
@@ -188,7 +188,7 @@ namespace HUDLayoutHelper {
 
         private unsafe void HandleMouseDownEvent(AddonEvent type, AddonArgs args) {
             if (args is not AddonReceiveEventArgs receiveEventArgs) return;
-            if (receiveEventArgs.AtkEventType != (uint)AtkEventType.MouseDown) return;
+            if ((AtkEventType)receiveEventArgs.AtkEventType != AtkEventType.MouseDown) return;
             if (receiveEventArgs.AtkEvent == nint.Zero) return;
 
             // Check if the event has the custom flag set, if so, filter it out
@@ -228,7 +228,7 @@ namespace HUDLayoutHelper {
 
         private unsafe void HandleMouseUpEvent(AddonEvent type, AddonArgs args) {
             if (args is not AddonReceiveEventArgs receiveEventArgs) return;
-            if (receiveEventArgs.AtkEventType != (uint)AtkEventType.MouseUp) return;
+            if ((AtkEventType)receiveEventArgs.AtkEventType != AtkEventType.MouseUp) return;
             if (receiveEventArgs.AtkEvent == nint.Zero) return;
 
 
@@ -408,7 +408,7 @@ namespace HUDLayoutHelper {
             this.Debug.Log(Plugin.Log.Debug, $"Keybind.Action: {keyboardAction}");
 
             // Abort if a popup is open
-            if (this.HudLayoutWindow->NumOpenPopups > 0) {
+            if (this.HudLayoutWindow->NumBlockingAddons > 0) {
                 this.Debug.Log(Plugin.Log.Warning, "Popup open, not executing action.");
                 return;
             }
@@ -686,7 +686,7 @@ namespace HUDLayoutHelper {
 
         private unsafe void HandleKeyboardMoveEvent(AddonEvent type, AddonArgs args) {
             if (args is not AddonReceiveEventArgs receiveEventArgs) return;
-            if (receiveEventArgs.AtkEventType != 13) // && (AtkEventType)receiveEventArgs.AtkEventType != AtkEventType.InputReceived) 
+            if ((byte)receiveEventArgs.AtkEventType != 13) // && (AtkEventType)receiveEventArgs.AtkEventType != AtkEventType.InputReceived)
                 return;
             if (receiveEventArgs.AtkEvent == nint.Zero) return;
 
@@ -700,7 +700,7 @@ namespace HUDLayoutHelper {
 
         private unsafe void HandleControllerMoveEvent(AddonEvent type, AddonArgs args) {
             if (args is not AddonReceiveEventArgs receiveEventArgs) return;
-            if (receiveEventArgs.AtkEventType != 15) // && (AtkEventType)receiveEventArgs.AtkEventType != AtkEventType.InputReceived) 
+            if ((byte)receiveEventArgs.AtkEventType != 15) // && (AtkEventType)receiveEventArgs.AtkEventType != AtkEventType.InputReceived)
                 return;
             if (receiveEventArgs.AtkEvent == nint.Zero) return;
 

--- a/HUDLayoutHelper/Utilities/Debug.cs
+++ b/HUDLayoutHelper/Utilities/Debug.cs
@@ -56,11 +56,11 @@ namespace HUDLayoutHelper.Utilities {
             };
 
             // Check if the event type is in the handled list
-            if (!handledTypeList.Contains((AtkEventType)receiveEventArgs.AtkEventType) && !handledByteEventList.Contains(receiveEventArgs.AtkEventType)) {
+            if (!handledTypeList.Contains((AtkEventType)receiveEventArgs.AtkEventType) && !handledByteEventList.Contains((byte)receiveEventArgs.AtkEventType)) {
                 return;
             }
 
-            if (receiveEventArgs.AtkEventType == 15) {
+            if ((byte)receiveEventArgs.AtkEventType == 15) {
                 if (receiveEventArgs.AtkEventData != nint.Zero) {
                     AtkEventData* eventDataTemp = (AtkEventData*)receiveEventArgs.AtkEventData;
                     if (eventDataTemp->ListItemData.SelectedIndex == 256) {

--- a/HUDLayoutHelper/packages.lock.json
+++ b/HUDLayoutHelper/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[14.0.1, )",
-        "resolved": "14.0.1",
-        "contentHash": "y0WWyUE6dhpGdolK3iKgwys05/nZaVf4ZPtIjpLhJBZvHxkkiE23zYRo7K7uqAgoK/QvK5cqF6l3VG5AbgC6KA=="
+        "requested": "[15.0.0, )",
+        "resolved": "15.0.0",
+        "contentHash": "411vwC8/X8Z/sQ2TI6v3SvOn66xFPeOjFn3Zn+h0d3Ox2t1kFm66AhDvmx/qcMwVrR+Hidxj0dadpQ2dgyXMBQ=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",


### PR DESCRIPTION
Fixes #2 the plugin currently targets Dalamud API 14, so it no longer loads on patch 7.5, which ships with Dalamud API 15.

## Changes
- Bump `Dalamud.NET.Sdk` 14.0.1 -> 15.0.0 and `DalamudApiLevel` / `TestingDalamudApiLevel` 14 -> 15.
- Adapt to API 15 breaking changes: `uint` updated the event-type comparisons accordingly.
- `AtkUnitBase.NumOpenPopups` was renamed to `NumBlockingAddons` in FFXIVClientStructs (same field/offset); updated the popup guard.